### PR TITLE
Fix: instantiate a new router for separated routes (fixes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 > A simple package to map your routes for your expressjs application
 
+---
+**IMPORTANT: v1.0.2 fixed a security vulnerability. Every version up to v1.0.1 is not save for production. Update your current version to v1.0.2. You can find more information [here](https://github.com/aichbauer/express-routes-mapper/issues/15).**
+---
+
 ## Getting started
 
 - [Install](#install)

--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,10 @@ import path from 'path';
 import splitByLastDot from './helpers/splitByLastDot';
 import isConstructor from './helpers/isConstrutor';
 
-const router = express.Router();
 const cwd = process.cwd();
 
 const mapRoutes = (routes, pathToController) => {
+  const router = express.Router();
   let requestMethodPath;
   let requestMethod;
 

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -8,8 +8,20 @@ const routes = {
   'DELETE /user/:name/:id': 'Function.Export.Default.destroy',
 };
 
+const privateRoutes = {
+  'GET /user': 'ClassExportDefault.get',
+  'POST /user/:name': 'ClassModuleExports.create',
+};
+
+const publicRoutes = {
+  'PUT /user/:name/:id': 'FunctionModuleExports.update',
+  'DELETE /user/:name/:id': 'Function.Export.Default.destroy',
+};
+
 test('testing', (t) => {
   const router = mapRoutes(routes, 'test/fixtures/controllers/');
+
+  t.is(router.stack.length, 4);
 
   // CLASS EXPORT DEFAULT
   // method
@@ -60,4 +72,13 @@ test('testing', (t) => {
   t.is('function', typeof (router.stack[3].route.stack[0].handle));
 
   t.is('function', typeof (router));
+});
+
+test('private and public are seperated', (t) => {
+  const router = mapRoutes(privateRoutes, 'test/fixtures/controllers/');
+  const router2 = mapRoutes(publicRoutes, 'test/fixtures/controllers/');
+
+  // check if routes are not available on other router
+  t.is(router.stack.length, 2);
+  t.is(router2.stack.length, 2);
 });


### PR DESCRIPTION
As mentioned in #15 there is a security issue. We need to instantiate a new router for every set of routes we pass (every time we call the function mapRoutes).