### PR TITLE
Fix: core js need to be v2 after update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ typings/
 
 # dotenv environment variables file
 .env
+
+.idea

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "@babel/register": "^7.0.0",
     "@babel/runtime": "^7.1.2",
     "express": "^4.16.3",
-    "object.entries": "^1.0.4"
+    "object.entries": "^1.0.4",
+    "core-js": "2"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",


### PR DESCRIPTION
corejs is upgraded to v3, need to add a fix version for v2 build